### PR TITLE
Add command to set the arglist by filtering all listed buffers

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -23,7 +23,7 @@ http://of-vim-and-vigor.blogspot.com/[beverages].
 * [optional] The system ++find++ command
 
 * [optional] https://github.com/dahu/Vimple[Vimple] (for the
-  https://github.com/dahu/Vimple[Vimple] Filter)
+  https://github.com/dahu/Vimple[Vimple] Filter and :VFMAB)
 
 ++VFMEdit++ relies on your +path+ option. Setting this to a Good
 Value is crucial for getting the best out of VFM. Begin with this

--- a/doc/vimfindsme.txt
+++ b/doc/vimfindsme.txt
@@ -81,6 +81,11 @@ The :Args command will set |:args| to the contents of the buffer.
                                                                   *Argadd*
 The :Argadd command will call |:argadd| with the contents of the buffer.
 
+                                                                  *VFMAB*
+:VFMAB~
+
+The VFMAB command displays the current buffer list using |vimple#ls|. Pressing
+|<enter>| in this window sets the args in the same manner as with |VFMArgs|.
 
                                                                    *VFMCD*
 :VFMCD~

--- a/doc/vimfindsme.txt
+++ b/doc/vimfindsme.txt
@@ -86,6 +86,7 @@ The :Argadd command will call |:argadd| with the contents of the buffer.
 
 The VFMAB command displays the current buffer list using |vimple#ls|. Pressing
 |<enter>| in this window sets the args in the same manner as with |VFMArgs|.
+If |vimple| is not installed, this command is not available.
 
                                                                    *VFMCD*
 :VFMCD~

--- a/plugin/vimfindsme.vim
+++ b/plugin/vimfindsme.vim
@@ -177,17 +177,19 @@ function! VimFindsMeArgs()
         \ })
 endfunction
 
-function! VFMArgsFromBufferList()
-  let auto_act = g:vfm_auto_act_on_single_filter_result
-  let g:vfm_auto_act_on_single_filter_result = 0
-  let buffer_names = map(vimple#ls#new().to_l('listed'), 'v:val.name')
-  call vfm#show_list_overlay(buffer_names)
-  let g:vfm_auto_act_on_single_filter_result = auto_act
-  call vfm#overlay_controller(
-        \ {
-        \  '<enter>' : ':call ' . s:SID() . 'vfm_args_callback()'
-        \ })
-endfunction
+if exists('*vimple#ls#new')
+  function! VFMArgsFromBufferList()
+    let auto_act = g:vfm_auto_act_on_single_filter_result
+    let g:vfm_auto_act_on_single_filter_result = 0
+    let buffer_names = map(vimple#ls#new().to_l('listed'), 'v:val.name')
+    call vfm#show_list_overlay(buffer_names)
+    let g:vfm_auto_act_on_single_filter_result = auto_act
+    call vfm#overlay_controller(
+          \ {
+          \  '<enter>' : ':call ' . s:SID() . 'vfm_args_callback()'
+          \ })
+  endfunction
+endif
 
 function! VFMArgument(arg)
   let arg = a:arg
@@ -216,10 +218,12 @@ function! VFMArglistComplete(ArgLead, CmdLine, CursorPos)
 endfunction
 
 " Commands: {{{1
+if exists('*vimple#ls#new')
+  command! -nargs=0 -bar          VFMAB       call VFMArgsFromBufferList()
+endif
 command! -nargs=0 -bar          VFMEdit     call VimFindsMeFiles(&path)
 command! -nargs=0 -bar          VFMCD       call VimFindsMeDirs()
 command! -nargs=1 -bar          VFMOpts     call VimFindsMeOpts(<q-args>)
-command! -nargs=0 -bar          VFMAB       call VFMArgsFromBufferList()
 command! -nargs=0 -bar          VFMArglist  call VimFindsMeArgs()
 command! -nargs=0 -bar -range=% VFMArgs
       \ exe 'args ' . join(getline(<line1>,<line2>), ' ')
@@ -234,7 +238,9 @@ nnoremap <silent> <plug>vfm_browse_dirs   :VFMCD<CR>
 nnoremap <silent> <plug>vfm_browse_paths  :call VimFindsMeOpts('&path')<CR>
 nnoremap <silent> <plug>vfm_browse_args   :VFMArglist<CR>
 nnoremap <silent> <plug>vfm_argument      :call feedkeys(":VFMArgument \<c-d>")<cr>
-nnoremap <silent> <plug>vfm_arg_buffers   :VFMAB<CR>
+if exists('*vimple#ls#new')
+  nnoremap <silent> <plug>vfm_arg_buffers   :VFMAB<CR>
+endif
 
 if !hasmapto('<plug>vfm_browse_files')
   nmap <unique><silent> <leader>ge <plug>vfm_browse_files

--- a/plugin/vimfindsme.vim
+++ b/plugin/vimfindsme.vim
@@ -177,19 +177,21 @@ function! VimFindsMeArgs()
         \ })
 endfunction
 
-if exists('*vimple#ls#new')
-  function! VFMArgsFromBufferList()
-    let auto_act = g:vfm_auto_act_on_single_filter_result
-    let g:vfm_auto_act_on_single_filter_result = 0
-    let buffer_names = map(vimple#ls#new().to_l('listed'), 'v:val.name')
-    call vfm#show_list_overlay(buffer_names)
-    let g:vfm_auto_act_on_single_filter_result = auto_act
-    call vfm#overlay_controller(
-          \ {
-          \  '<enter>' : ':call ' . s:SID() . 'vfm_args_callback()'
-          \ })
-  endfunction
-endif
+function! VFMArgsFromBufferList()
+  if !exists('*vimple#ls#new')
+    echom 'VFMArgsFromBufferList requires vimple to be installed!'
+    return
+  endif
+  let auto_act = g:vfm_auto_act_on_single_filter_result
+  let g:vfm_auto_act_on_single_filter_result = 0
+  let buffer_names = map(vimple#ls#new().to_l('listed'), 'v:val.name')
+  call vfm#show_list_overlay(buffer_names)
+  let g:vfm_auto_act_on_single_filter_result = auto_act
+  call vfm#overlay_controller(
+        \ {
+        \  '<enter>' : ':call ' . s:SID() . 'vfm_args_callback()'
+        \ })
+endfunction
 
 function! VFMArgument(arg)
   let arg = a:arg
@@ -218,12 +220,10 @@ function! VFMArglistComplete(ArgLead, CmdLine, CursorPos)
 endfunction
 
 " Commands: {{{1
-if exists('*vimple#ls#new')
-  command! -nargs=0 -bar          VFMAB       call VFMArgsFromBufferList()
-endif
 command! -nargs=0 -bar          VFMEdit     call VimFindsMeFiles(&path)
 command! -nargs=0 -bar          VFMCD       call VimFindsMeDirs()
 command! -nargs=1 -bar          VFMOpts     call VimFindsMeOpts(<q-args>)
+command! -nargs=0 -bar          VFMAB       call VFMArgsFromBufferList()
 command! -nargs=0 -bar          VFMArglist  call VimFindsMeArgs()
 command! -nargs=0 -bar -range=% VFMArgs
       \ exe 'args ' . join(getline(<line1>,<line2>), ' ')
@@ -238,9 +238,7 @@ nnoremap <silent> <plug>vfm_browse_dirs   :VFMCD<CR>
 nnoremap <silent> <plug>vfm_browse_paths  :call VimFindsMeOpts('&path')<CR>
 nnoremap <silent> <plug>vfm_browse_args   :VFMArglist<CR>
 nnoremap <silent> <plug>vfm_argument      :call feedkeys(":VFMArgument \<c-d>")<cr>
-if exists('*vimple#ls#new')
-  nnoremap <silent> <plug>vfm_arg_buffers   :VFMAB<CR>
-endif
+nnoremap <silent> <plug>vfm_arg_buffers   :VFMAB<CR>
 
 if !hasmapto('<plug>vfm_browse_files')
   nmap <unique><silent> <leader>ge <plug>vfm_browse_files

--- a/plugin/vimfindsme.vim
+++ b/plugin/vimfindsme.vim
@@ -177,6 +177,18 @@ function! VimFindsMeArgs()
         \ })
 endfunction
 
+function! VFMArgsFromBufferList()
+  let auto_act = g:vfm_auto_act_on_single_filter_result
+  let g:vfm_auto_act_on_single_filter_result = 0
+  let buffer_names = map(vimple#ls#new().to_l('listed'), 'v:val.name')
+  call vfm#show_list_overlay(buffer_names)
+  let g:vfm_auto_act_on_single_filter_result = auto_act
+  call vfm#overlay_controller(
+        \ {
+        \  '<enter>' : ':call ' . s:SID() . 'vfm_args_callback()'
+        \ })
+endfunction
+
 function! VFMArgument(arg)
   let arg = a:arg
   if (type(arg) == type(0)) || (arg =~ '^\d\+$')
@@ -207,6 +219,7 @@ endfunction
 command! -nargs=0 -bar          VFMEdit     call VimFindsMeFiles(&path)
 command! -nargs=0 -bar          VFMCD       call VimFindsMeDirs()
 command! -nargs=1 -bar          VFMOpts     call VimFindsMeOpts(<q-args>)
+command! -nargs=0 -bar          VFMAB       call VFMArgsFromBufferList()
 command! -nargs=0 -bar          VFMArglist  call VimFindsMeArgs()
 command! -nargs=0 -bar -range=% VFMArgs
       \ exe 'args ' . join(getline(<line1>,<line2>), ' ')
@@ -221,6 +234,7 @@ nnoremap <silent> <plug>vfm_browse_dirs   :VFMCD<CR>
 nnoremap <silent> <plug>vfm_browse_paths  :call VimFindsMeOpts('&path')<CR>
 nnoremap <silent> <plug>vfm_browse_args   :VFMArglist<CR>
 nnoremap <silent> <plug>vfm_argument      :call feedkeys(":VFMArgument \<c-d>")<cr>
+nnoremap <silent> <plug>vfm_arg_buffers   :VFMAB<CR>
 
 if !hasmapto('<plug>vfm_browse_files')
   nmap <unique><silent> <leader>ge <plug>vfm_browse_files
@@ -240,6 +254,10 @@ endif
 
 if !hasmapto('<plug>vfm_argument')
   nmap <unique><silent> <leader>gg <plug>vfm_argument
+endif
+
+if !hasmapto('<plug>vfm_arg_buffers')
+  nmap <unique><silent> <leader>gc <plug>vfm_arg_buffers
 endif
 
 " Autocommands {{{1


### PR DESCRIPTION
I've added a new command :VFMAB.

This command does essentially the same as :VFMArglist, but instead of starting
with the argument list, it starts with the entire buffer list (gotten via vimple).

The idea is that if you want to change you're current argument list, you can
select from all available buffers.

There's some repitition between VFMArgsFromBufferList and VimFindsMeArgs, that
I wasn't sure whether you'd want refactored away or not, and I haven't kept to
the naming convention for external functions as I couldn't think of a good
VimFindsMe... name, so if you want either changed I'm happy to do so.
